### PR TITLE
Persistent Country selection

### DIFF
--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -247,8 +247,8 @@ class _HomePageState extends State<HomePage> {
         color: Colors.white54,
         fontSize: 24.0,
       ),
-      onConfirm: (Picker picker, List value) {
-        viewModel.selectCountry(picker.adapter.text);
+      onConfirm: (Picker picker, List value) async {
+        await viewModel.selectCountry(picker.adapter.text);
       },
     ).showModal(this.context);
   }

--- a/lib/storage/user_storage.dart
+++ b/lib/storage/user_storage.dart
@@ -1,0 +1,14 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class UserStorage {
+  Future<String> getCountryName() async {
+    SharedPreferences prefs = await SharedPreferences.getInstance();
+    String selectedCountry = prefs.getString('country') ?? 'global';
+    return selectedCountry;
+  }
+
+  Future<void> setCountryName(String countryName) async {
+    SharedPreferences prefs = await SharedPreferences.getInstance();
+    await prefs.setString('country', countryName);
+  }
+}

--- a/lib/storage/user_storage.dart
+++ b/lib/storage/user_storage.dart
@@ -1,14 +1,16 @@
 import 'package:shared_preferences/shared_preferences.dart';
 
 class UserStorage {
-  Future<String> getCountryName() async {
+  String selectedCountry;
+
+  Future<void> getCountryName() async {
     SharedPreferences prefs = await SharedPreferences.getInstance();
-    String selectedCountry = prefs.getString('country') ?? 'global';
-    return selectedCountry;
+    selectedCountry = prefs.getString('country') ?? 'global';
   }
 
   Future<void> setCountryName(String countryName) async {
     SharedPreferences prefs = await SharedPreferences.getInstance();
     await prefs.setString('country', countryName);
+    selectedCountry = countryName;
   }
 }

--- a/lib/viewmodel/covid_home_viewmodel.dart
+++ b/lib/viewmodel/covid_home_viewmodel.dart
@@ -26,18 +26,18 @@ class CovidHomeViewModel with ChangeNotifier {
     this.stats = await repository.getAllStats();
 
     _fetchCountries();
+    await storage.getCountryName();
     await _setSelected();
     _setLoadingStats(false);
   }
 
   Future<void> _setSelected() async {
-    String countryName = await storage.getCountryName();
-    countryName == 'global'
+    storage.selectedCountry == 'global'
         ? this.selected =
             stats.firstWhere((element) => element.country.iso2Lower == 'global')
         : this.selected = this.stats.firstWhere(
-            (element) =>
-                element.country.name.contains(_clearSelection(countryName)),
+            (element) => element.country.name
+                .contains(_clearSelection(storage.selectedCountry)),
             orElse: null);
   }
 

--- a/lib/viewmodel/covid_home_viewmodel.dart
+++ b/lib/viewmodel/covid_home_viewmodel.dart
@@ -27,11 +27,11 @@ class CovidHomeViewModel with ChangeNotifier {
 
     _fetchCountries();
     await storage.getCountryName();
-    await _setSelected();
+    _setSelected();
     _setLoadingStats(false);
   }
 
-  Future<void> _setSelected() async {
+  void _setSelected() {
     storage.selectedCountry == 'global'
         ? this.selected =
             stats.firstWhere((element) => element.country.iso2Lower == 'global')
@@ -50,7 +50,7 @@ class CovidHomeViewModel with ChangeNotifier {
     _setLoadingCountries(false);
   }
 
-  void selectCountry(String countryName) async {
+  Future<void> selectCountry(String countryName) async {
     this.selected = this.stats.firstWhere(
         (element) =>
             element.country.name.contains(_clearSelection(countryName)),

--- a/lib/viewmodel/covid_home_viewmodel.dart
+++ b/lib/viewmodel/covid_home_viewmodel.dart
@@ -2,6 +2,7 @@ import 'package:covidviewerflutter/model/chart_stat_data.dart';
 import 'package:covidviewerflutter/model/country.dart';
 import 'package:covidviewerflutter/model/country_stats.dart';
 import 'package:covidviewerflutter/repository/covid_repository.dart';
+import 'package:covidviewerflutter/storage/user_storage.dart';
 import 'package:flutter/material.dart';
 
 class CovidHomeViewModel with ChangeNotifier {
@@ -17,6 +18,7 @@ class CovidHomeViewModel with ChangeNotifier {
   bool isLoadingStats = false;
   bool isLoadingCountries = false;
   Exception loadStatsException;
+  UserStorage storage = UserStorage();
 
   Future<void> fetchStats() async {
     _setLoadingStats(true);
@@ -24,13 +26,19 @@ class CovidHomeViewModel with ChangeNotifier {
     this.stats = await repository.getAllStats();
 
     _fetchCountries();
-    _setSelected();
+    await _setSelected();
     _setLoadingStats(false);
   }
 
-  void _setSelected() {
-    this.selected =
-        stats.firstWhere((element) => element.country.iso2Lower == 'global');
+  Future<void> _setSelected() async {
+    String countryName = await storage.getCountryName();
+    countryName == 'global'
+        ? this.selected =
+            stats.firstWhere((element) => element.country.iso2Lower == 'global')
+        : this.selected = this.stats.firstWhere(
+            (element) =>
+                element.country.name.contains(_clearSelection(countryName)),
+            orElse: null);
   }
 
   void _fetchCountries() {
@@ -42,11 +50,12 @@ class CovidHomeViewModel with ChangeNotifier {
     _setLoadingCountries(false);
   }
 
-  void selectCountry(String countryName) {
+  void selectCountry(String countryName) async {
     this.selected = this.stats.firstWhere(
         (element) =>
             element.country.name.contains(_clearSelection(countryName)),
         orElse: null);
+    await storage.setCountryName(_clearSelection(countryName));
     notifyListeners();
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   provider: ^4.0.4
   charts_flutter: ^0.9.0
   cupertino_icons: ^0.1.3
+  shared_preferences: ^0.5.12+2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Fixes #5 Persistent Country selection

**Changes**
Using the `shared_preferences`  plugin, the selected country is stored locally. Now user don't have to search and select their country every time the app is launched.

