### PR TITLE
Updated homepage UI

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -8,11 +8,18 @@ class App extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      debugShowCheckedModeBanner: false,
-      title: 'Covid World Stats',
-      home: ChangeNotifierProvider(
-        create: (context) => CovidHomeViewModel(),
-        child: HomePage(),
+      theme: ThemeData(
+          brightness: Brightness.dark,
+          primaryColor: Colors.blueGrey
+      ),
+      home: Scaffold(
+        appBar: AppBar(
+          title: const Text('Covid World Stats'),
+        ),
+        body: ChangeNotifierProvider(
+          create: (context) => CovidHomeViewModel(),
+          child: HomePage(),
+        ),
       ),
     );
   }

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -52,18 +52,27 @@ class _HomePageState extends State<HomePage> {
         crossAxisAlignment: CrossAxisAlignment.center,
         mainAxisSize: MainAxisSize.max,
         children: <Widget>[
+
           Expanded(
-            child: Padding(
-              padding: const EdgeInsets.only(left: 8.0),
-              child: Text(
-                'Covid World Stats',
-                style: TextStyle(
-                  color: Colors.white54,
-                  fontSize: 20.0,
+            child: InkWell(
+              onTap: (){
+                _showPickerModal(context, viewModel);
+              },
+              child: Padding(
+                padding: const EdgeInsets.only(left: 8.0),
+                child: Text(
+                  viewModel.selected?.country?.name ?? '',
+                  style: TextStyle(
+                    color: Colors.white54,
+                    fontSize: 20.0,
+                  ),
                 ),
+
               ),
             ),
           ),
+
+
           viewModel.selected?.country?.iso2Lower == 'global'
               ? Image.network(
                   'https://icons.iconarchive.com/icons/icons-land/vista-flags/256/United-Nations-Flag-1-icon.png',
@@ -76,7 +85,7 @@ class _HomePageState extends State<HomePage> {
                   : Container()),
           viewModel.isLoadingStats
               ? Padding(
-                  padding: const EdgeInsets.all(16.0),
+                  padding: const EdgeInsets.only(left: 300.0),//all(20.0),
                   child: Container(
                     height: 16.0,
                     width: 16.0,
@@ -177,13 +186,6 @@ class _HomePageState extends State<HomePage> {
                   crossAxisAlignment: CrossAxisAlignment.center,
                   mainAxisSize: MainAxisSize.max,
                   children: <Widget>[
-                    Text(
-                      viewModel.selected?.country?.name ?? '',
-                      style: TextStyle(
-                          color: Colors.white54,
-                          fontWeight: FontWeight.w600,
-                          fontSize: 20.0),
-                    ),
                     Row(
                       crossAxisAlignment: CrossAxisAlignment.center,
                       mainAxisAlignment: MainAxisAlignment.center,


### PR DESCRIPTION
Fixes #14  
This is how the new homepage UI looks like. I created the appBar to display "Covid World Stats" and the navBar now displays the the country name. Furthermore, instead of only the search icon being clickable, the country name is now also clickable (clicking on the country name or search icon will bring up the country picker, `_showPickerModal(context, viewModel)`).

| Before | After |
| :---: | :---: |
| <img src="https://cdn.discordapp.com/attachments/755279998394564688/766489190875267122/unknown.png" width=200> |  <img src="https://cdn.discordapp.com/attachments/755279998394564688/766520493057507339/unknown.png" width=205> | 

Please let me know what you think and if you want me to change anything, thank you.